### PR TITLE
Replace file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 ## Project Hiatus
 
-Due to the overwhelming support for translations, Linux Journey is in the middle of a site overhaul to make it more scalable for translations. Unfortunately, I am a full time professional and full time student so it has taken longer to do the migration than I had hoped. For now, any additional translations/edits/additions will not be added to the site. I'll try my best to finish adding everything that was already committed and will re-visit the project when I have more cycles. Thank you for understanding.
+> Due to the overwhelming support for translations, Linux Journey is in the middle of a site overhaul to make it more scalable for translations. Unfortunately, I am a full time professional and full time student so it has taken longer to do the migration than I had hoped. For now, any additional translations/edits/additions will not be added to the site. I'll try my best to finish adding everything that was already committed and will re-visit the project when I have more cycles. Thank you for understanding.
+> 
+> - [@cindyq](https://github.com/cindyq)
+
+I've created this fork for maintenance of the project. You guys can make contributions to that, and, if [@cindyq](https://github.com/cindyq) ever back, we can just merge. Otherwise, we can keep continuing this awesome project
+
+If you have any translation, any dead pull request here, any suggestion, etc. Just open an issue in a PR in the fork.
 
 ## Language Support
 

--- a/lessons/locales/en_english/access/setuid-set-user-id.md
+++ b/lessons/locales/en_english/access/setuid-set-user-id.md
@@ -44,7 +44,7 @@ As you can see the SUID is denoted by a 4 and pre-pended to the permission set. 
 
 ## Exercise
 
-Look at the permission for /etc/passwd in detail, do you notice anything else? Files with SUID enabled are also easily distinguishable.
+Look at the permission for /usr/bin/passwd in detail, do you notice anything else? Files with SUID enabled are also easily distinguishable.
 
 ## Quiz Question
 

--- a/lessons/locales/en_english/access/setuid-set-user-id.md
+++ b/lessons/locales/en_english/access/setuid-set-user-id.md
@@ -4,22 +4,22 @@
 
 There are many cases in which normal users need elevated access to do stuff. The system administrator can't always be there to enter in a root password every time a user needed access to a protected file, so there are special file permission bits to allow this behavior. The Set User ID (SUID) allows a user to run a program as the owner of the program file rather than as themselves.
 
-Let's look at an example: 
+Let's look at an example:
 
 Let's say I want to change my password, simple right? I just use the passwd command:
 
 <pre>$ passwd</pre>
 
-What is the password command doing? It's modifying a couple of files, but most importantly it's modifying the /etc/shadow file. Let's look at that file for a second: 
+What is the password command doing? It's modifying a couple of files, but most importantly it's modifying the /etc/shadow file. Let's look at that file for a second:
 
 <pre>$ ls -l /etc/shadow
 
 -rw-r----- 1 root shadow 1134 Dec 1 11:45 /etc/shadow
 </pre>
 
-Oh wait a minute here, this file is owned by root? How is it possible that we are able to modify a file owned by root? 
+Oh wait a minute here, this file is owned by root? How is it possible that we are able to modify a file owned by root?
 
-Let's look at another permission set, this time of the command we ran: 
+Let's look at another permission set, this time of the command we ran:
 
 <pre>$ ls -l /usr/bin/passwd
 
@@ -28,11 +28,11 @@ Let's look at another permission set, this time of the command we ran:
 
 You'll notice a new permission bit here <b>s</b>. This permission bit is the SUID, when a file has this permission set, it allows the users who launched the program to get the file owner's permission as well as execution permission, in this case root. So essentially while a user is running the password command, they are running as root.
 
-That's why we are able to access a protected file like /etc/shadow when we run the passwd command. Now if you removed that bit, you would see that you will not be able to modify /etc/shadow and therefore change your password. 
+That's why we are able to access a protected file like /etc/shadow when we run the passwd command. Now if you removed that bit, you would see that you will not be able to modify /etc/shadow and therefore change your password.
 
 <b>Modifying SUID</b>
 
-Just like regular permissions there are two ways to modify SUID permissions. 
+Just like regular permissions there are two ways to modify SUID permissions.
 
 <i>Symbolic way:</i>
 <pre>$ sudo chmod u+s myfile</pre>

--- a/lessons/locales/en_english/network-troubleshooting/icmp.md
+++ b/lessons/locales/en_english/network-troubleshooting/icmp.md
@@ -2,7 +2,7 @@
 
 ## Lesson Content
 
-The Internet Control Message Protocol (ICMP) is part of the TCP/IP protocol suite, it used to send updates and error messages and is an extremely useful protocol used for debugging network issues such as a failed packet delivery.
+The Internet Control Message Protocol (ICMP) is part of the TCP/IP protocol suite, it is used to send updates and error messages and is an extremely useful protocol used for debugging network issues such as a failed packet delivery.
 
 Each ICMP message contains a type, code and checksum field. The type field is the type of ICMP message, the code is a sub-type and describes more information about the message and the checksum is used to detect any issues with the integrity of the message.
 
@@ -15,7 +15,7 @@ Let's look at some common ICMP Types:
 <li>Type 11 - Time Exceeded</li>
 </ul>
 
-When a packet can't get to a destination, Type 3 ICMP message is generated, within Type 3 there are 16 code values that will further describe why it can't get to the destination: 
+When a packet can't get to a destination, Type 3 ICMP message is generated, within Type 3 there are 16 code values that will further describe why it can't get to the destination:
 
 <ul>
 <li>Code 0 - Network Unreachable</li>

--- a/lessons/locales/en_english/network-troubleshooting/netstat.md
+++ b/lessons/locales/en_english/network-troubleshooting/netstat.md
@@ -6,12 +6,12 @@
 
 We've discussed data transmission through ports on our machine, let's look at some well known ports.
 
-You can get a list of well-known ports by looking at the file <b>/etc/services</b>: 
+You can get a list of well-known ports by looking at the file <b>/etc/services</b>:
 
 <pre>
 ftp             21/tcp
 ssh             22/tcp
-smtp            25/tcp 
+smtp            25/tcp
 domain          53/tcp  # DNS
 http            80/tcp
 https           443/tcp
@@ -22,23 +22,23 @@ The first column is the name of the service, then the port number and the transp
 
 <b>netstat</b>
 
-An extremely useful tool to get detailed information about your network is <b>netstat</b>. Netstat displays various network related information such network connections, routing tables, information about network interfaces and more, it's the swiss army knife of networking tools. We will focus mostly on one feature netstat has and that's the status of network connections. Before we look at an example, let's talk about sockets and ports first. A socket is an interface that allows programs to send and receive data while a port is used to identify which application should send or receive data. The socket address is the combination of the IP address and port. Every connection between a host and destination requires a unique socket. For example, HTTP is a service that runs on port 80, however we can have many HTTP connections and to maintain each connection a socket gets created per connection.
+An extremely useful tool to get detailed information about your network is <b>netstat</b>. Netstat displays various network related information such as network connections, routing tables, information about network interfaces and more, it's the swiss army knife of networking tools. We will focus mostly on one feature netstat has and that's the status of network connections. Before we look at an example, let's talk about sockets and ports first. A socket is an interface that allows programs to send and receive data while a port is used to identify which application should send or receive data. The socket address is the combination of the IP address and port. Every connection between a host and destination requires a unique socket. For example, HTTP is a service that runs on port 80, however we can have many HTTP connections and to maintain each connection a socket gets created per connection.
 
 <pre>
 pete@icebox:~$ netstat -at
 Active Internet connections (servers and established)
-Proto Recv-Q Send-Q Local Address           Foreign Address         State      
-tcp        0      0 icebox:domain           *:*                     LISTEN     
-tcp        0      0 localhost:ipp           *:*                     LISTEN     
-tcp        0      0 icebox.lan:44468        124.28.28.50:http       TIME_WAIT  
-tcp        0      0 icebox.lan:34751        124.28.29.50:http       TIME_WAIT  
-tcp        0      0 icebox.lan:34604        economy.canonical.:http TIME_WAIT  
-tcp6       0      0 ip6-localhost:ipp       [::]:*                  LISTEN     
-tcp6       1      0 ip6-localhost:35094     ip6-localhost:ipp       CLOSE_WAIT 
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+tcp        0      0 icebox:domain           *:*                     LISTEN
+tcp        0      0 localhost:ipp           *:*                     LISTEN
+tcp        0      0 icebox.lan:44468        124.28.28.50:http       TIME_WAIT
+tcp        0      0 icebox.lan:34751        124.28.29.50:http       TIME_WAIT
+tcp        0      0 icebox.lan:34604        economy.canonical.:http TIME_WAIT
+tcp6       0      0 ip6-localhost:ipp       [::]:*                  LISTEN
+tcp6       1      0 ip6-localhost:35094     ip6-localhost:ipp       CLOSE_WAIT
 tcp6       0      0 ip6-localhost:ipp       ip6-localhost:35094     FIN_WAIT2
 </pre>
 
-The netstat -a command shows the listening and non-listening sockets for network connections, the -t flag shows only tcp connections. 
+The netstat -a command shows the listening and non-listening sockets for network connections, the -t flag shows only tcp connections.
 
 The columns are as follows from left to right:
 

--- a/lessons/locales/en_english/network-troubleshooting/packet-analysis.md
+++ b/lessons/locales/en_english/network-troubleshooting/packet-analysis.md
@@ -28,7 +28,7 @@ listening on wlan0, link-type EN10MB (Ethernet), capture size 65535 bytes
 11:28:31.190665 IP ThePickleParty.lan.51056 > 192.168.86.255.rfe: UDP, length 306
 </pre>
 
-You'll notice a lot of stuff happening when you run a packet capture, well that's to be expected there's a lot of network activity happening in the background. In my above example, I've taken only a snippet of my capture specifically the time when I decided to ping www.google.com. 
+You'll notice a lot of stuff happening when you run a packet capture, well that's to be expected there's a lot of network activity happening in the background. In my above example, I've taken only a snippet of my capture specifically the time when I decided to ping www.google.com.
 
 <b>Understanding the output</b>
 
@@ -41,7 +41,7 @@ You'll notice a lot of stuff happening when you run a packet capture, well that'
 <li>The first field is a timestamp of the network activity</li>
 <li>IP, this contains the protocol information</li>
 <li>Next, you'll see the source and destination address: icebox.lan > nuq04s29-in-f4.1e100.net</li>
-<li>seq, this is the TCP packets's starting and ending sequence number</li>
+<li>seq, this is the TCP packet's starting and ending sequence number</li>
 <li>length, length in bytes</li>
 </ul>
 


### PR DESCRIPTION
This PR does the following:

- Replaces the file /etc/passwd with /usr/bin/passwd for the exercise of the lesson setuid-set-user-id
- Removes spaces at the end of lines for the aforementioned lesson.
