### PR TITLE
Fix quiz answer in Vim Navigation lesson (Advanced Text-Fu)

### DIFF
--- a/lessons/en/text-fu-advanced/vim-navigation.md
+++ b/lessons/en/text-fu-advanced/vim-navigation.md
@@ -30,4 +30,4 @@ What letter is used to move down?
 
 ## Quiz Answer
 
-k
+j


### PR DESCRIPTION
This PR corrects a mistake in the **Vim Navigation** lesson under _Advanced Text-Fu._

- The quiz question asks: **“What letter is used to move down?”**
- The current answer is incorrect (k).
- Updated the answer to j, which is the correct Vim key for moving down.

This fix applies only to the English lesson. Other translations may still contain the same mistake and should be updated by the translation workflow.