### PR TITLE
Update Package Repositories lesson with note on new Ubuntu .sources format

### DIFF
--- a/lessons/en/packages/package-repositories.md
+++ b/lessons/en/packages/package-repositories.md
@@ -17,6 +17,12 @@ Now, instead of going to their website to download the package directly, you can
 
 Your distribution already comes with pre-approved sources to get packages from, and this is how it installs all the base packages you see on your system. On a Debian system, this sources file is the `/etc/apt/sources.list` file. Your machine will know to look there and check for any source repositories you added.
 
+> **Note:** On older Debian/Ubuntu systems, repositories are listed in `/etc/apt/sources.list`.  
+> On newer Ubuntu versions (22.04 and above), sources have been migrated to structured files in `/etc/apt/sources.list.d/`, such as `ubuntu.sources`.  
+> Both formats are supported by `apt`, but you may see either depending on your system.
+
+
+
 ## Exercise
 
 Practice makes perfect! Here are some hands-on labs to reinforce your understanding of Linux package management and repositories:


### PR DESCRIPTION
This PR updates the "Package Repositories" lesson to mention that on newer Ubuntu versions (22.04+),
APT sources have migrated from `/etc/apt/sources.list` to structured `.sources` files in `/etc/apt/sources.list.d/`.

- Keeps the original explanation for beginners (using `/etc/apt/sources.list`).
- Adds a short note clarifying the new format (`ubuntu.sources`).
- Helps learners avoid confusion when `/etc/apt/sources.list` is empty on modern Ubuntu systems.
